### PR TITLE
Fix path issue in getConfigPath function

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,10 +38,12 @@ func getConfig(path string) *viper.Viper {
 func getConfigPath() string {
 	_, b, _, _ := runtime.Caller(0)
 	basepath := filepath.Dir(b)
+	if runtime.GOOS == "windows" {
+		basepath = strings.Replace(basepath, "\\", "/", -1)
+	}
 	index := strings.LastIndex(basepath, "/pkg")
 	if index != -1 {
 		basepath = basepath[:index]
 	}
-
 	return basepath
 }


### PR DESCRIPTION
Fix crash on windows.

![image](https://github.com/vinirossado/gcli-advanced-template/assets/28675529/8fc30219-eccc-4c11-8120-061f8fc97815)
